### PR TITLE
Add metric: average_claim_amount_by_member

### DIFF
--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -150,3 +150,12 @@ metrics:
       measure: member_responsibility
     filter: |
       {{ Dimension('claim__claim_date') }} >= '2024-01-01'
+metrics:
+  - name: average_claim_amount_by_member
+    description: "Average claim amount per member"
+    type: ratio
+    label: "Average Claim Amount by Member"
+    type_params:
+      numerator: total_claim_amount
+      denominator: active_members
+    filter: null


### PR DESCRIPTION
## Summary
- Added new metric: `average_claim_amount_by_member`

## Details
I am adding a new ratio metric called 'average_claim_amount_by_member' that calculates the average claim amount per member. This metric uses the existing 'total_claim_amount' as the numerator and 'active_members' as the denominator. No new measures are needed as both required measures already exist in the semantic models.

## Test Plan
- [ ] Run `dbt parse` to validate YAML syntax
- [ ] Run `dbt build` to ensure models compile
- [ ] Query the new metric via Semantic Layer to verify it works
- [ ] Check that the metric appears in downstream applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)
