### PR TITLE
Add metric: average_claim_amount

### DIFF
--- a/models/semantic/semantic_models.yml
+++ b/models/semantic/semantic_models.yml
@@ -150,3 +150,11 @@ metrics:
       measure: member_responsibility
     filter: |
       {{ Dimension('claim__claim_date') }} >= '2024-01-01'
+metrics:
+  - name: average_claim_amount
+    description: "Average dollar amount of claims"
+    type: ratio
+    label: "Average Claim Amount"
+    type_params:
+      numerator: total_claim_amount
+      denominator: total_claims_count


### PR DESCRIPTION
## Summary
- Added new metric: `average_claim_amount`

## Details
I am adding a new ratio metric named 'average_claim_amount'. This metric calculates the average claim amount by dividing the total claim amount by the total number of claims. The necessary measures 'total_claim_amount' and 'claim_count' already exist in the semantic model, so no new measures are needed.

## Test Plan
- [ ] Run `dbt parse` to validate YAML syntax
- [ ] Run `dbt build` to ensure models compile
- [ ] Query the new metric via Semantic Layer to verify it works
- [ ] Check that the metric appears in downstream applications

🤖 Generated via AI Benefits Portal
